### PR TITLE
Handle failed match in common#formatRemotes.

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -161,6 +161,7 @@ export function formatRemotes(remotes: string[]) : string[] {
       rem.match(/github\.com/)
         ? rem.replace(/\.git(\b|$)/, '')
         : rem),
+    R.reject(R.isNil),
     R.map(rem => {
       if (rem.match(/^https?:/)) {
         return rem.replace(/\.git(\b|$)/, '');


### PR DESCRIPTION
This handles the case of having a symlink to another repo in the root of the main repo, which causes `git remote -v` to return
```
origin	git@github.com:user/main.git (fetch)
origin	git@github.com:user/main.git (push)
other	../other (fetch)
other	../other (push)
```